### PR TITLE
feat(share): add OTP sharing without exposing secret key

### DIFF
--- a/app/api/secrets/[id]/share/route.ts
+++ b/app/api/secrets/[id]/share/route.ts
@@ -1,0 +1,107 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  const secret = await prisma.secret.findFirst({
+    where: {
+      id,
+      userId: session.user.id,
+    },
+    include: {
+      share: true,
+    },
+  });
+
+  if (!secret) {
+    return NextResponse.json({ error: "Secret not found" }, { status: 404 });
+  }
+
+  if (secret.share) {
+    return NextResponse.json({ token: secret.share.token });
+  }
+
+  const share = await prisma.sharedSecret.create({
+    data: {
+      secretId: id,
+    },
+  });
+
+  return NextResponse.json({ token: share.token });
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  const secret = await prisma.secret.findFirst({
+    where: {
+      id,
+      userId: session.user.id,
+    },
+  });
+
+  if (!secret) {
+    return NextResponse.json({ error: "Secret not found" }, { status: 404 });
+  }
+
+  await prisma.sharedSecret.deleteMany({
+    where: {
+      secretId: id,
+    },
+  });
+
+  return NextResponse.json({ success: true });
+}
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  const secret = await prisma.secret.findFirst({
+    where: {
+      id,
+      userId: session.user.id,
+    },
+    include: {
+      share: true,
+    },
+  });
+
+  if (!secret) {
+    return NextResponse.json({ error: "Secret not found" }, { status: 404 });
+  }
+
+  if (!secret.share) {
+    return NextResponse.json({ token: null });
+  }
+
+  return NextResponse.json({ token: secret.share.token });
+}

--- a/app/api/secrets/route.ts
+++ b/app/api/secrets/route.ts
@@ -17,10 +17,23 @@ export async function GET() {
       secret: true,
       label: true,
       createdAt: true,
+      share: {
+        select: {
+          token: true,
+        },
+      },
     },
   });
 
-  return NextResponse.json(secrets);
+  const result = secrets.map((s) => ({
+    id: s.id,
+    secret: s.secret,
+    label: s.label,
+    createdAt: s.createdAt,
+    shareToken: s.share?.token || null,
+  }));
+
+  return NextResponse.json(result);
 }
 
 export async function POST(request: Request) {
@@ -69,10 +82,23 @@ export async function POST(request: Request) {
       secret: true,
       label: true,
       createdAt: true,
+      share: {
+        select: {
+          token: true,
+        },
+      },
     },
   });
 
-  return NextResponse.json(allSecrets);
+  const result = allSecrets.map((s) => ({
+    id: s.id,
+    secret: s.secret,
+    label: s.label,
+    createdAt: s.createdAt,
+    shareToken: s.share?.token || null,
+  }));
+
+  return NextResponse.json(result);
 }
 
 export async function PATCH(request: Request) {

--- a/app/api/share/[token]/route.ts
+++ b/app/api/share/[token]/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import * as OTPAuth from "otpauth";
+
+function generateTOTP(secret: string): { otp: string; timeLeft: number } | null {
+  try {
+    const totp = new OTPAuth.TOTP({
+      algorithm: "SHA1",
+      digits: 6,
+      period: 30,
+      secret: OTPAuth.Secret.fromBase32(secret),
+    });
+
+    return {
+      otp: totp.generate(),
+      timeLeft: Math.ceil(totp.remaining() / 1000),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ token: string }> }
+) {
+  const { token } = await params;
+
+  const share = await prisma.sharedSecret.findUnique({
+    where: { token },
+    include: {
+      secret: {
+        select: {
+          secret: true,
+          label: true,
+        },
+      },
+    },
+  });
+
+  if (!share) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const result = generateTOTP(share.secret.secret);
+
+  if (!result) {
+    return NextResponse.json({ error: "Invalid secret" }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    label: share.secret.label,
+    otp: result.otp,
+    timeLeft: result.timeLeft,
+  });
+}

--- a/app/share/[token]/page.tsx
+++ b/app/share/[token]/page.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useState, useEffect, useCallback, use } from "react";
+
+interface OTPData {
+  label: string;
+  otp: string;
+  timeLeft: number;
+}
+
+export default function SharePage({ params }: { params: Promise<{ token: string }> }) {
+  const { token } = use(params);
+  const [data, setData] = useState<OTPData | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [timeLeft, setTimeLeft] = useState(30);
+  const [copied, setCopied] = useState(false);
+
+  const fetchOTP = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/share/${token}`);
+      if (!res.ok) {
+        if (res.status === 404) {
+          setError("Share link tidak valid atau sudah di-revoke");
+        } else {
+          setError("Gagal mengambil OTP");
+        }
+        return;
+      }
+      const json = await res.json();
+      setData(json);
+      setTimeLeft(json.timeLeft);
+      setError(null);
+    } catch {
+      setError("Gagal mengambil OTP");
+    } finally {
+      setLoading(false);
+    }
+  }, [token]);
+
+  useEffect(() => {
+    fetchOTP();
+  }, [fetchOTP]);
+
+  useEffect(() => {
+    if (!data) return;
+
+    const interval = setInterval(() => {
+      setTimeLeft((prev) => {
+        if (prev <= 1) {
+          fetchOTP();
+          return 30;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [data, fetchOTP]);
+
+  useEffect(() => {
+    if (!copied) return;
+    const timeout = setTimeout(() => setCopied(false), 1500);
+    return () => clearTimeout(timeout);
+  }, [copied]);
+
+  const copyToClipboard = async () => {
+    if (!data) return;
+    await navigator.clipboard.writeText(data.otp);
+    setCopied(true);
+  };
+
+  const progress = timeLeft / 30;
+  const circumference = 2 * Math.PI * 12;
+  const strokeDashoffset = circumference * (1 - progress);
+
+  if (loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-zinc-50 dark:bg-zinc-950">
+        <div className="h-8 w-8 animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-600 dark:border-zinc-700 dark:border-t-zinc-400" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-zinc-50 dark:bg-zinc-950">
+        <div className="text-center">
+          <svg
+            className="mx-auto h-12 w-12 text-zinc-400 dark:text-zinc-600"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+          >
+            <circle cx="12" cy="12" r="10" />
+            <path d="M12 8v4M12 16h.01" />
+          </svg>
+          <p className="mt-4 text-zinc-600 dark:text-zinc-400">{error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  return (
+    <div className="relative flex min-h-screen items-center justify-center bg-zinc-50 dark:bg-zinc-950">
+      <div className="bg-texture pointer-events-none absolute inset-0 opacity-[0.03] dark:opacity-[0.04]" />
+
+      <main className="relative w-full max-w-sm px-6 py-12">
+        <h1 className="mb-8 flex items-center justify-center gap-3 text-4xl font-bold tracking-widest">
+          <span className="bg-gradient-to-b from-zinc-600 to-zinc-900 bg-clip-text text-transparent dark:from-zinc-200 dark:to-zinc-500">
+            2FA
+          </span>
+          <div className="h-8 w-8">
+            <svg className="h-8 w-8 -rotate-90" viewBox="0 0 28 28">
+              <circle
+                cx="14"
+                cy="14"
+                r="12"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="4"
+                className="text-zinc-800 dark:text-zinc-700"
+              />
+              <circle
+                cx="14"
+                cy="14"
+                r="12"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="4"
+                strokeLinecap="round"
+                strokeDasharray={circumference}
+                strokeDashoffset={strokeDashoffset}
+                className={`transition-all duration-1000 ease-linear ${
+                  timeLeft <= 5 ? "text-red-500" : "text-zinc-400 dark:text-zinc-300"
+                }`}
+              />
+            </svg>
+          </div>
+        </h1>
+
+        <button
+          onClick={copyToClipboard}
+          className="group w-full cursor-pointer rounded-lg bg-zinc-900 p-6 text-left transition-colors hover:bg-zinc-800/50 dark:bg-zinc-800 dark:hover:bg-zinc-700/50"
+        >
+          <div className="mb-2 text-sm text-zinc-400">{data.label}</div>
+          <div className="font-mono text-4xl font-bold tracking-widest text-white">
+            {data.otp.slice(0, 3)} {data.otp.slice(3)}
+          </div>
+          <div className="mt-2 text-xs text-zinc-500">
+            {copied ? (
+              <span className="text-zinc-400">Copied</span>
+            ) : (
+              <span>Click to copy</span>
+            )}
+          </div>
+        </button>
+
+        <p className="mt-6 text-center text-xs text-zinc-500">
+          OTP akan diperbarui otomatis setiap 30 detik
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/prisma/migrations/20251219000000_add_shared_secret/migration.sql
+++ b/prisma/migrations/20251219000000_add_shared_secret/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "SharedSecret" (
+    "id" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "secretId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "SharedSecret_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SharedSecret_token_key" ON "SharedSecret"("token");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SharedSecret_secretId_key" ON "SharedSecret"("secretId");
+
+-- AddForeignKey
+ALTER TABLE "SharedSecret" ADD CONSTRAINT "SharedSecret_secretId_fkey" FOREIGN KEY ("secretId") REFERENCES "Secret"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -56,13 +56,22 @@ model VerificationToken {
 }
 
 model Secret {
-  id        String   @id @default(cuid())
+  id        String         @id @default(cuid())
   userId    String
   secret    String
   label     String
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  createdAt DateTime       @default(now())
+  updatedAt DateTime       @updatedAt
+  user      User           @relation(fields: [userId], references: [id], onDelete: Cascade)
+  share     SharedSecret?
 
   @@unique([userId, secret])
+}
+
+model SharedSecret {
+  id        String   @id @default(cuid())
+  token     String   @unique @default(cuid())
+  secretId  String   @unique
+  secret    Secret   @relation(fields: [secretId], references: [id], onDelete: Cascade)
+  createdAt DateTime @default(now())
 }


### PR DESCRIPTION
## Summary
- Add OTP sharing feature that allows users to share OTP codes without exposing the secret key
- OTP is generated server-side so the secret remains secure
- Share links are public and permanent until revoked by the owner

## Changes
- `prisma/schema.prisma` - Add `SharedSecret` model
- `app/api/secrets/[id]/share/route.ts` - API to create/revoke share
- `app/api/share/[token]/route.ts` - Public API to get OTP
- `app/share/[token]/page.tsx` - Public page for recipients
- `app/page.tsx` - Add share button + modal

## Notes
- Share feature only appears for logged-in users
- Auto-refresh OTP only when expired (saves API calls for Vercel free tier)
- Migration is additive, does not modify existing data